### PR TITLE
修复时间转换卡顿的问题

### DIFF
--- a/HoloCubic_Firmware/src/app/weather/weather.cpp
+++ b/HoloCubic_Firmware/src/app/weather/weather.cpp
@@ -68,7 +68,7 @@ void UpdateTime_RTC(lv_scr_load_anim_t anim_type)
     time_t t;
     t = (time_t)(timestamp / 1000);
     time_struct = gmtime(&t);
-    strftime(date, sizeof(date), "%y-%m-%d", time_struct);
+    strftime(date, sizeof(date), "%Y-%m-%d", time_struct);
     strftime(time, sizeof(time), "%H:%M", time_struct);
 
     display_time(date, time, anim_type);

--- a/HoloCubic_Firmware/src/app/weather/weather.cpp
+++ b/HoloCubic_Firmware/src/app/weather/weather.cpp
@@ -56,10 +56,22 @@ void UpdateTime_RTC(lv_scr_load_anim_t anim_type)
     }
 
     g_rtc.setTime(timestamp / 1000);
-    String date = g_rtc.getDate(String("%Y-%m-%d"));
-    String time = g_rtc.getTime(String("%H:%M"));
 
-    display_time(date.c_str(), time.c_str(), anim_type);
+    //阻塞时间太长（高达10S）
+    // String date = g_rtc.getDate(String("%Y-%m-%d"));
+    // String time = g_rtc.getTime(String("%H:%M"));
+    
+    //底层调用时间转换
+    struct tm *time_struct;
+    char date[30];
+    char time[30];
+    time_t t;
+    t = (time_t)(timestamp / 1000);
+    time_struct = gmtime(&t);
+    strftime(date, sizeof(date), "%y-%m-%d", time_struct);
+    strftime(time, sizeof(time), "%H:%M", time_struct);
+
+    display_time(date, time, anim_type);
 }
 
 void weather_init(void)


### PR DESCRIPTION
天气APP中，天气页面和时钟页面，切换不跟手，排查发现是时间转换耗费太多时间导致卡顿，因此调用更底层的时间转换解决的卡顿问题